### PR TITLE
Increase app memory limit to 512Mi

### DIFF
--- a/charts/neops/values.yaml
+++ b/charts/neops/values.yaml
@@ -72,10 +72,10 @@ app:
   resources:
     limits:
       cpu: 500m
-      memory: 256Mi
+      memory: 512Mi
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 256Mi
 
 
 ########################################################################################


### PR DESCRIPTION
The current value of 256Mi results in app container getting OOM killed in demo/preview environment